### PR TITLE
Increased compatibility to magento-composer-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "webguys/easytemplate",
   "license": "MIT",
+  "type": "magento-module",
   "authors": [
     {
       "name": "Matthias Kleine"


### PR DESCRIPTION
If type is magento-module the module can be automatically deployed to a modman folder instead of being linked to `vendor/composer/...` when you have these lines in your projects `composer.json`:

`````` js
// [...]
"extra": {
    "installer-paths": {
      ".modman/{$name}/": [
        "type:magento-module"
      ]
    }
  }```
``````
