### PR TITLE
missing ACLs prevent proper display of system/config settings

### DIFF
--- a/app/code/community/Webguys/Easytemplate/etc/adminhtml.xml
+++ b/app/code/community/Webguys/Easytemplate/etc/adminhtml.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<config>
+    <acl>
+        <resources>
+            <all>
+                <title>Allow Everything</title>
+            </all>
+            <admin>
+                <children>
+                    <system>
+                        <children>
+                            <config>
+                                <children>
+                                    <easytemplate translate="title" module="easytemplate">
+                                        <title>Webguys EasyTemplate</title>
+                                    </easytemplate>
+                                </children>
+                            </config>
+                        </children>
+                    </system>
+                </children>
+            </admin>
+        </resources>
+    </acl>
+</config>


### PR DESCRIPTION
without those, we get a 404 on the system/config settings (Magento CE 1.9.2.2)
