### PR TITLE
add preparation for categories in frontend (analog to the product way)

### DIFF
--- a/app/code/community/Webguys/Easytemplate/Model/Input/Renderer/Validator/Category.php
+++ b/app/code/community/Webguys/Easytemplate/Model/Input/Renderer/Validator/Category.php
@@ -6,6 +6,14 @@
  */
 class Webguys_Easytemplate_Model_Input_Renderer_Validator_Category extends Webguys_Easytemplate_Model_Input_Renderer_Validator_Base
 {
+    public function prepareForFrontend($data)
+    {
+        /** @var $product Mage_Catalog_Model_Category */
+        $category = Mage::getModel('catalog/category');
+        $category->load($data);
+
+        return ($category->getId()) ? $category : false;
+    }
 
     public function prepareForSave($data)
     {

--- a/app/design/frontend/base/default/template/easytemplate/template/youtube.phtml
+++ b/app/design/frontend/base/default/template/easytemplate/template/youtube.phtml
@@ -5,7 +5,7 @@
         <iframe
             width="<?php echo $this->getData('width'); ?>"
             height="<?php echo $this->getData('height'); ?>"
-            src="http://www.youtube.com/embed/<?php echo $video_id; ?>?rel=0" frameborder="0" <?php echo $this->getData(
+            src="//www.youtube.com/embed/<?php echo $video_id; ?>?rel=0" frameborder="0" <?php echo $this->getData(
             'allowfullscreen'
         ); ?>>
         </iframe>


### PR DESCRIPTION
When we use a configured category in the template, we have a category id. Let's do it like the product way so that we have a real category model in the frontend.
