### PR TITLE
add permission to save and delete CMS blocks

### DIFF
--- a/app/code/community/Webguys/Easytemplate/etc/adminhtml.xml
+++ b/app/code/community/Webguys/Easytemplate/etc/adminhtml.xml
@@ -18,6 +18,22 @@
                             </config>
                         </children>
                     </system>
+                    <cms>
+                        <children>
+                            <block>
+                                <children>
+                                    <save translate="title">
+                                        <title>Save Block</title>
+                                        <sort_order>0</sort_order>
+                                    </save>
+                                    <delete translate="title">
+                                        <title>Delete Block</title>
+                                        <sort_order>10</sort_order>
+                                    </delete>
+                                </children>
+                            </block>
+                        </children>
+                    </cms>
                 </children>
             </admin>
         </resources>


### PR DESCRIPTION
In #27 there is the problem, that in `\Webguys_Easytemplate_Block_Adminhtml_Cms_Block_Edit::_isAllowedAction` we ask for permission `cms/block/save` but in standard Magento we have only permission for `cms/block` (not like in the pages section). I decided to add permissions `cms/block/save`and `cms/block/delete` instead of using permission `cms/block` like in default Magento.
