### PR TITLE
inherit easytemplates from default store view to specific store view

### DIFF
--- a/app/code/community/Webguys/Easytemplate/Helper/Category.php
+++ b/app/code/community/Webguys/Easytemplate/Helper/Category.php
@@ -11,7 +11,9 @@ class Webguys_Easytemplate_Helper_Category extends Mage_Core_Helper_Abstract
     /**
      * Returns an existing block entry or creates a new one
      *
-     * @param $id CategoryId
+     * @param int $id ID of category to handle
+     * @param int $store_id ID of store to handle
+     * @param boolean $store_fallback fall back to default scope is there is nothing on store view scope
      * @return Webguys_Easytemplate_Model_Group
      */
     public function getGroupByCategoryId($id, $store_id, $store_fallback = false)
@@ -24,6 +26,13 @@ class Webguys_Easytemplate_Helper_Category extends Mage_Core_Helper_Abstract
 
         if ($store_fallback) {
             $collection->addFieldToFilter('store_id', array('in' => array($store_id, 0)));
+
+            // do not use empty store view groups and also filter deactivated items
+            $collection->getSelect()
+                ->joinLeft('easytemplate','easytemplate.group_id = main_table.id AND active = 1', array())
+                ->group(array('group_id','store_id'))
+                ->having('(count(easytemplate.group_id) > 0 AND store_id != 0) OR store_id = 0')
+            ;
         } else {
             $collection->addFieldToFilter('store_id', $store_id);
         }
@@ -43,7 +52,7 @@ class Webguys_Easytemplate_Helper_Category extends Mage_Core_Helper_Abstract
             $newItem->setEntityType(self::ENTITY_TYPE_CATEGORY);
             $newItem->setEntityId($id);
             $newItem->setStoreId($store_id);
-            //$newItem->save();
+            $newItem->save();
 
             return $newItem;
         }

--- a/app/code/community/Webguys/Easytemplate/Helper/Category.php
+++ b/app/code/community/Webguys/Easytemplate/Helper/Category.php
@@ -43,7 +43,7 @@ class Webguys_Easytemplate_Helper_Category extends Mage_Core_Helper_Abstract
             $newItem->setEntityType(self::ENTITY_TYPE_CATEGORY);
             $newItem->setEntityId($id);
             $newItem->setStoreId($store_id);
-            $newItem->save();
+            //$newItem->save();
 
             return $newItem;
         }

--- a/app/code/community/Webguys/Easytemplate/Model/Observer.php
+++ b/app/code/community/Webguys/Easytemplate/Model/Observer.php
@@ -213,12 +213,6 @@ class Webguys_Easytemplate_Model_Observer extends Mage_Core_Model_Abstract
             $category->getStoreId()
         );
 
-        if ($group->getTemplateCollection()->getSize() == 0) {
-            // Do not save easytemplate on category when it has no items.
-            // So a fallback of empty categories on store view scope to easytemplate on default scope is possible
-            return;
-        }
-
         /** @var $helper Webguys_Easytemplate_Helper_Data */
         $helper = Mage::helper('easytemplate');
         $helper->saveTemplateInformation($group);

--- a/app/code/community/Webguys/Easytemplate/Model/Observer.php
+++ b/app/code/community/Webguys/Easytemplate/Model/Observer.php
@@ -213,6 +213,12 @@ class Webguys_Easytemplate_Model_Observer extends Mage_Core_Model_Abstract
             $category->getStoreId()
         );
 
+        if ($group->getTemplateCollection()->getSize() == 0) {
+            // Do not save easytemplate on category when it has no items.
+            // So a fallback of empty categories on store view scope to easytemplate on default scope is possible
+            return;
+        }
+
         /** @var $helper Webguys_Easytemplate_Helper_Data */
         $helper = Mage::helper('easytemplate');
         $helper->saveTemplateInformation($group);


### PR DESCRIPTION
At the moment the behaviour with Easytemplates on categories is, that when I configure some Easytemplate in default scope and then look in the frontend on store view scope, the Easytemplate contents are visible as espected.

After I opened the category in the backend on store view scope without any change, in the frontend a blank Easytemplate area will be shown (because nothing is configured on store view scope).

I think it's a better behaviour to only show the Easytemplate of store view scope when something is configured there. So we have the standard Magento behaviour with store view scope fallback on default scope.
