### PR TITLE
support templates without any field

### DIFF
--- a/app/code/community/Webguys/Easytemplate/Model/Template.php
+++ b/app/code/community/Webguys/Easytemplate/Model/Template.php
@@ -82,7 +82,11 @@ class Webguys_Easytemplate_Model_Template extends Mage_Core_Model_Abstract
             $this->setValidTo(date('Y-m-d', $time));
         }
 
-        $this->_field_data = $data['fields'];
+        if (array_key_exists('fields', $data)) {
+            $this->_field_data = $data['fields'];
+        } else {
+            $this->_field_data = array();
+        }
     }
 
     protected function _isValid()


### PR DESCRIPTION
When someone want to add Easytemplate templates without any field, some error message occured. I think it's a real world use case to support this, because there can be some static area like styled content divider, which you want to support to be configurable within an Easytemplate.
