### PR TITLE
Added loop break to avoid conflicts

### DIFF
--- a/app/code/community/Webguys/Easytemplate/Model/Observer.php
+++ b/app/code/community/Webguys/Easytemplate/Model/Observer.php
@@ -35,6 +35,8 @@ class Webguys_Easytemplate_Model_Observer extends Mage_Core_Model_Abstract
                         'disabled' => false,
                     )
                 );
+                /** Break the loop after default/first fieldset */
+                break; 
             }
         }
     }


### PR DESCRIPTION
If you are running other extensions which extend cms admin form with additional fieldset you get in trouble because easytemplate will add more than one field with id "view_mode". Breaking the loop after inserting "view_mode" field fixed that kind of conflicts.
