### PR TITLE
PHP 7 Kompatibilitätsproblem

### DIFF
--- a/app/code/community/Webguys/Easytemplate/Block/Adminhtml/Edit/Renderer.php
+++ b/app/code/community/Webguys/Easytemplate/Block/Adminhtml/Edit/Renderer.php
@@ -18,7 +18,7 @@ class Webguys_Easytemplate_Block_Adminhtml_Edit_Renderer
         return $this->_template_model;
     }
 
-    public function setTemplateModel(Webguys_Easytemplate_Model_Template $model)
+    public function setTemplateModel($model)
     {
         $this->_template_model = $model;
         return $this;


### PR DESCRIPTION
Die Funktion setTemplateModel erfordert ein Objekt von Typ Webguys_Easytemplate_Model_Template. Im Backend, wenn die Boxen aus der easytemplate.xml geladen werden, wird allerdings ein Webguys_Easytemplate_Model_Input_Parser_Template übergeben. PHP 7 wirft an der Stelle einen Fehler und legt das Backend lahm.