### PR TITLE
Bugfix for unknwon block identifier

### DIFF
--- a/app/code/community/Webguys/Easytemplate/Helper/Block.php
+++ b/app/code/community/Webguys/Easytemplate/Helper/Block.php
@@ -10,7 +10,7 @@ class Webguys_Easytemplate_Helper_Block extends Mage_Core_Helper_Abstract
 
     public function isEasyTemplateBlock($blockId)
     {
-        $block = Mage::getSingleton('cms/block');
+        $block = Mage::getModel('cms/block');
         $block->setStoreId(Mage::app()->getStore()->getId());
         $block->load($blockId);
 


### PR DESCRIPTION
If ``$block->load($blockId);`` does not find a result, the data from the last result will be used, which not correct.