### PR TITLE
#56: do not hide option to choose CMS block for category

### DIFF
--- a/app/design/adminhtml/default/default/template/easytemplate/edit/template.phtml
+++ b/app/design/adminhtml/default/default/template/easytemplate/edit/template.phtml
@@ -156,11 +156,6 @@
             $('block_content').addClassName('ignore-validate');
             $('block_tabs_content_section').hide();
         }
-
-        // Category mode
-        if ($$('select[name=general[landing_page]]').first()) {
-            $$('select[name=general[landing_page]]').first().up().up().hide();
-        }
     }
 
     function sortableUpdate() {


### PR DESCRIPTION
In my environment Easytemplate work correct also when we allow to choose a CMS block in the category,