### PR TITLE
fix template path of slider

### DIFF
--- a/app/code/community/Webguys/Easytemplate/etc/easytemplate.xml
+++ b/app/code/community/Webguys/Easytemplate/etc/easytemplate.xml
@@ -280,7 +280,7 @@
                         </amount>
                     </fields>
                 </spacer>
-                <slider template="easytemplate/slider.phtml" type="easytemplate/template"
+                <slider template="easytemplate/template/slider.phtml" type="easytemplate/template"
                         translate="label,comment">
                     <enabled>1</enabled>
                     <label>Slider</label>

--- a/app/locale/de_DE/Webguys_Easytemplate.csv
+++ b/app/locale/de_DE/Webguys_Easytemplate.csv
@@ -94,3 +94,5 @@
 "Import from ZIP-File","ZIP-Datei importieren"
 "Import Templates","Bausteine importieren"
 "Export Templates","Bausteine exportieren"
+"Speed in MS","Geschwindigkeit in ms"
+"Add new Slide-Item","Neue Folie hinzufügen"


### PR DESCRIPTION
In the `easytemplate.xml` there is a wrong template path to a not existing template of slider.