### PR TITLE
use subtemplate for slider item

### DIFF
--- a/app/code/community/Webguys/Easytemplate/etc/easytemplate.xml
+++ b/app/code/community/Webguys/Easytemplate/etc/easytemplate.xml
@@ -280,7 +280,7 @@
                         </amount>
                     </fields>
                 </spacer>
-                <slider template="easytemplate/slider.phtml" type="easytemplate/template"
+                <slider template="easytemplate/template/slider.phtml" type="easytemplate/template"
                         translate="label,comment">
                     <enabled>1</enabled>
                     <label>Slider</label>
@@ -304,7 +304,7 @@
                         </item>
                     </fields>
                 </slider>
-                <slider_item type="easytemplate/template">
+                <slider_item template="easytemplate/template/slider_item.phtml" type="easytemplate/template">
                     <hidden>1</hidden>
                     <enabled>1</enabled>
                     <label>Link/Bild</label>

--- a/app/design/frontend/base/default/template/easytemplate/template/slider.phtml
+++ b/app/design/frontend/base/default/template/easytemplate/template/slider.phtml
@@ -5,9 +5,7 @@
         <div class="col-xs-12 ">
             <div id="slider">
                 <?php foreach ($this->getChildTemplates() as $child): ?>
-                    <div class="image" style="background-image: url('<?php echo $child->getData('image') ?>')">
-                        <span><?php echo $child->getData('link_text') ?></span>
-                    </div>
+                    <?php echo $child->toHtml() ?>
                 <?php endforeach; ?>
             </div>
         </div>

--- a/app/design/frontend/base/default/template/easytemplate/template/slider_item.phtml
+++ b/app/design/frontend/base/default/template/easytemplate/template/slider_item.phtml
@@ -1,0 +1,4 @@
+<?php /** @var $this Webguys_Easytemplate_Block_Template */ ?>
+<div class="image" style="background-image: url('<?php echo $this->getData('image') ?>')">
+    <span><?php echo $this->getData('link_text') ?></span>
+</div>


### PR DESCRIPTION
To handle the slider items granular it's better to have a subtemplate. We have a whole children block here and it's more easy to adopt to other use cases in the future if we use the normal Magento block handling.