### PR TITLE
add hint to strtotime to inspire use of datepicker default value

### DIFF
--- a/app/code/community/Webguys/Easytemplate/etc/easytemplate.xml
+++ b/app/code/community/Webguys/Easytemplate/etc/easytemplate.xml
@@ -564,6 +564,7 @@
                             <!-- <backend_model>easytemplate/template_data_datetime</backend_model> -->
                             <input_renderer>easytemplate/input_renderer_datepicker</input_renderer>
                             <sort_order>120</sort_order>
+                            <!-- you can use all out of strtotime like "now" or "+1 week" as default value -->
                             <default_value>2013-12-05</default_value>
                             <required>0</required>
                         </datepicker_test>


### PR DESCRIPTION
It's a cool feature, that we support strtotime on datepicker values. Let's add some documentation in the example fields area to make it easier to adopt.