### PR TITLE
[BUGFIX] Fix valid date logic with current date

### DIFF
--- a/app/code/community/Webguys/Easytemplate/Block/Renderer.php
+++ b/app/code/community/Webguys/Easytemplate/Block/Renderer.php
@@ -54,7 +54,9 @@ class Webguys_Easytemplate_Block_Renderer extends Mage_Core_Block_Template
             $configModel = Mage::getSingleton('easytemplate/input_parser');
 
             $position = 1;
-            $time = Mage::app()->getLocale()->storeTimeStamp(Mage::app()->getStore()->getId());
+
+            $storeDate = Mage::app()->getLocale()->storeDate(Mage::app()->getStore()->getId());
+            $time = $storeDate->getTimestamp();
 
             /** @var $template Webguys_Easytemplate_Model_Template */
             foreach ($group->getTemplateCollection($parent) as $template) {


### PR DESCRIPTION
If the validFrom or validTo dates are set to e.g. 08.02.2018 and you view the page on this date, the element is not shown because the timestamp is greater than the validFrom date or validTo date. This is not correct. 

This PR fixes this behaviour by use the timestamp of the current store date without the current time of the day.