### PR TITLE
[TASK] Allow that product selection can be removed

### DIFF
--- a/app/code/community/Webguys/Easytemplate/Block/Input/Renderer/Link.php
+++ b/app/code/community/Webguys/Easytemplate/Block/Input/Renderer/Link.php
@@ -58,6 +58,9 @@ class Webguys_Easytemplate_Block_Input_Renderer_Link extends Webguys_Easytemplat
     public function getName()
     {
         $model = $this->getEntityModel();
+        if (!$model->getId()) {
+            return '-';
+        }
 
         if ($this->getEntityCode() == 'product') {
             return '<div class="hover">#' . $model->getId() . ': ' . $model->getName() . '<span class="tooltip">' . $this->__('Sku') . ': ' . $model->getSku() . '</span></div>';

--- a/app/code/community/Webguys/Easytemplate/Block/Input/Renderer/Product.php
+++ b/app/code/community/Webguys/Easytemplate/Block/Input/Renderer/Product.php
@@ -30,6 +30,10 @@ class Webguys_Easytemplate_Block_Input_Renderer_Product extends Webguys_Easytemp
     public function getName()
     {
         $model = $this->getEntityModel();
+        if (!$model->getId()) {
+            return '-';
+        }
+
         return '#' . $model->getId() . ': ' . $model->getSku() . ' - ' . $model->getName();
     }
 

--- a/app/design/adminhtml/default/default/template/easytemplate/edit/template.phtml
+++ b/app/design/adminhtml/default/default/template/easytemplate/edit/template.phtml
@@ -315,6 +315,16 @@
                 }
                 sortableUpdate();
             },
+            removeProductSelection: function(code, id) {
+                var label = 'template_field_' + code + '_' + id + 'label';
+                $(label).update('-');
+
+                var value = 'template_field_' + code + '_' + id + 'value';
+                $(value).value = '';
+
+                var remove = 'template_field_' + code + '_' + id + 'remove';
+                $(remove).style.display = 'none';
+            },
             dateTimeChanged: function (event) {
 
                 var dateTimeTarget = null;

--- a/app/design/adminhtml/default/default/template/easytemplate/input/renderer/product.phtml
+++ b/app/design/adminhtml/default/default/template/easytemplate/input/renderer/product.phtml
@@ -36,6 +36,10 @@
                             class="scalable" type="button">
                         <span><span><span><?php echo $this->__('Please Select') ?></span></span></span>
                     </button>
+
+                    <?php if ($this->getName() != '-'): ?>
+                    <a id="template_field_<?php echo $this->getCode(); ?>_{{id}}remove" href="javascript:void(0);" onclick="easyTemplate.removeProductSelection('<?php echo $this->getCode(); ?>', '{{id}}')"><?php echo $this->__('Remove Selection')?></a>
+                    <?php endif; ?>
                 </div>
             </td>
             <td class="comment">

--- a/app/locale/de_DE/Webguys_Easytemplate.csv
+++ b/app/locale/de_DE/Webguys_Easytemplate.csv
@@ -96,3 +96,4 @@
 "Export Templates","Bausteine exportieren"
 "Speed in MS","Geschwindigkeit in ms"
 "Add new Slide-Item","Neue Folie hinzufügen"
+"Remove Selection","Auswahl entfernen"


### PR DESCRIPTION
Currently, if the user has a product selected, the selected product can not be removed. The selection can only be changed. If you no longer want a product selected you currently need to remove the template and add it again which is time-consuming.

This PR adds a link to remove the selected product.